### PR TITLE
[김우성 코드리뷰용] mobile에서 wear로 데이터 전송 구현

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Wear_OS_Square_API_30.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_31.avd" />
           </Key>
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-10-16T18:29:45.321290Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-10-16T19:37:45.994155Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\Minhee\.android\avd\Wear_OS_Large_Round_API_28.avd" />
+            <value value="$USER_HOME$/.android/avd/Wear_OS_Square_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-10-15T06:34:10.303579700Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-10-16T18:29:45.321290Z" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.0" apply false
+    id("com.android.application") version "8.1.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
 }

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 
 android {
     namespace = "com.example.wear_study"
-    compileSdk = 33
+    compileSdk = 34
+
+    buildFeatures {
+        compose = true
+    }
 
     defaultConfig {
         applicationId = "com.example.wear_study"
@@ -26,21 +30,34 @@ android {
             )
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.4"
+    }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.gms:play-services-wearable:18.0.0")
-    implementation("com.google.android.material:material:1.9.0")
+    implementation("com.google.android.gms:play-services-wearable:18.1.0")
+    implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/mobile/src/main/java/com/example/wear_study/MainActivity.kt
+++ b/mobile/src/main/java/com/example/wear_study/MainActivity.kt
@@ -1,11 +1,64 @@
 package com.example.wear_study
 
+import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import com.google.android.gms.wearable.Wearable
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        findWearableNode(this)
+        setContent {
+            MaterialTheme {
+                // A surface container using the 'background' color from the theme
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    Button(onClick = {
+                        Log.d("PhoneApp", connectedNodeID.toString())
+                        sendMessageToWearable(this, "/count", "hello".toByteArray())
+                    }) {
+                        Text("Send")
+                    }
+                }
+            }
+        }
+    }
+}
+
+var connectedNodeID: String? = null
+
+fun findWearableNode(context: Context) {
+    Wearable.getNodeClient(context).connectedNodes
+        .addOnSuccessListener { nodes ->
+            connectedNodeID = nodes.find { it.isNearby }?.id
+        }
+        .addOnFailureListener { e ->
+            Log.e("PhoneApp", "Failed to retrieve nodes", e)
+        }
+}
+
+fun sendMessageToWearable(context: Context, path: String, data: ByteArray) {
+    connectedNodeID?.let { nodeId ->
+        Wearable.getMessageClient(context).sendMessage(nodeId, path, data)
+            .addOnSuccessListener {
+                Log.d("PhoneApp", "Message sent successfully")
+            }
+            .addOnFailureListener { e ->
+                Log.e("PhoneApp", "Failed to send message", e)
+            }
+    } ?: run {
+        Log.e("PhoneApp", "No connected node found")
     }
 }

--- a/mobile/src/main/java/com/example/wear_study/MainActivity.kt
+++ b/mobile/src/main/java/com/example/wear_study/MainActivity.kt
@@ -6,18 +6,29 @@ import android.os.Bundle
 import android.util.Log
 import com.google.android.gms.wearable.Wearable
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 class MainActivity : AppCompatActivity() {
+    private val context = this
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
         findWearableNode(this)
+        setContentView(R.layout.activity_main)
         setContent {
             MaterialTheme {
                 // A surface container using the 'background' color from the theme
@@ -25,11 +36,41 @@ class MainActivity : AppCompatActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Button(onClick = {
-                        Log.d("PhoneApp", connectedNodeID.toString())
-                        sendMessageToWearable(this, "/count", "hello".toByteArray())
-                    }) {
-                        Text("Send")
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        var count by remember { mutableStateOf(0) }
+                        Text("Count: $count")
+                        Row() {
+                            Button(
+                                onClick = {
+                                    count = 0
+                                    sendMessageToWearable(
+                                        context,
+                                        "/count",
+                                        "0".toByteArray()
+                                    )
+                                },
+                                modifier = Modifier.padding(8.dp)
+                            ) {
+                                Text("Initialize")
+                            }
+                            Button(
+                                onClick = {
+                                    count++
+                                    sendMessageToWearable(
+                                        context,
+                                        "/count",
+                                        count.toString().toByteArray()
+                                    )
+                                },
+                                modifier = Modifier.padding(8.dp)
+                            ) {
+                                Text("Add count")
+                            }
+                        }
                     }
                 }
             }

--- a/wear/src/main/java/com/example/wear_study/presentation/MainActivity.kt
+++ b/wear/src/main/java/com/example/wear_study/presentation/MainActivity.kt
@@ -7,8 +7,8 @@
 package com.example.wear_study.presentation
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,14 +24,25 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.example.wear_study.R
 import com.example.wear_study.presentation.theme.WearstudyTheme
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.Wearable
 
-class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-//        setContent {
-//            WearApp("Android")
-//        }
+
+        Wearable.getMessageClient(this).addListener(this)
+    }
+
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        Log.d("WearApp", "Message received: ${String(messageEvent.data)}")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Wearable.getMessageClient(this).removeListener(this)
     }
 }
 

--- a/wear/src/main/java/com/example/wear_study/presentation/MainActivity.kt
+++ b/wear/src/main/java/com/example/wear_study/presentation/MainActivity.kt
@@ -37,7 +37,13 @@ class MainActivity : ComponentActivity(), MessageClient.OnMessageReceivedListene
     }
 
     override fun onMessageReceived(messageEvent: MessageEvent) {
-        Log.d("WearApp", "Message received: ${String(messageEvent.data)}")
+        val message = String(messageEvent.data)
+        Log.d("WearApp", "Message received: $message")
+        val sharedPref = getSharedPreferences("WatchFacePreferences", MODE_PRIVATE)
+        with(sharedPref.edit()) {
+            putString("message", message)
+            apply()
+        }
     }
 
     override fun onDestroy() {

--- a/wear/src/main/java/com/example/wear_study/watchface/DualCanvasRenderer.kt
+++ b/wear/src/main/java/com/example/wear_study/watchface/DualCanvasRenderer.kt
@@ -1,13 +1,15 @@
 package com.example.wear_study.watchface
 
 import android.content.ContentValues.TAG
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Rect
 import android.graphics.RectF
-import android.graphics.drawable.shapes.OvalShape
 import android.util.Log
 import android.view.SurfaceHolder
 import androidx.wear.watchface.ComplicationSlot
@@ -20,11 +22,12 @@ import androidx.wear.watchface.style.CurrentUserStyleRepository
 import java.time.ZonedDateTime
 
 class DualCanvasRenderer(
+    context: Context,
     surfaceHolder: SurfaceHolder,
     currentUserStyleRepository: CurrentUserStyleRepository,
     watchState: WatchState, canvasType: Int,
     clearWithBackgroundTintBeforeRenderingHighlightLayer: Boolean
-) : Renderer.CanvasRenderer2<DualAssets> (
+) : Renderer.CanvasRenderer2<DualAssets>(
     surfaceHolder,
     currentUserStyleRepository,
     watchState,
@@ -32,6 +35,22 @@ class DualCanvasRenderer(
     interactiveDrawModeUpdateDelayMillis = 16L,
     clearWithBackgroundTintBeforeRenderingHighlightLayer
 ), WatchFace.TapListener {
+    private val sharedPrefChangeListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
+            invalidate() // Invalidate the renderer to trigger a redraw
+        }
+
+    private val sharedPref = context.getSharedPreferences("WatchFacePreferences", MODE_PRIVATE)
+
+    override fun onDestroy() {
+        sharedPref.unregisterOnSharedPreferenceChangeListener(sharedPrefChangeListener)
+    }
+
+    init {
+        // Register the listener
+        sharedPref.registerOnSharedPreferenceChangeListener(sharedPrefChangeListener)
+    }
+
     var isTapped = false;
     val bg_light = Color.parseColor("#f8dfb6");
     val bg_dark = Color.parseColor("#46698c");
@@ -55,9 +74,14 @@ class DualCanvasRenderer(
         zonedDateTime: ZonedDateTime,
         sharedAssets: DualAssets
     ) {
+        val message = sharedPref.getString("message", null) ?: "No message received"
         val h_width = bounds.width() / 2f
         val h_height = bounds.height() / 2f
         val p_black = Paint()
+        val p_message = Paint()
+
+        p_message.color = Color.BLACK
+        p_message.textSize = 50f
 
         if (isTapped) {
             canvas.drawColor(bg_light)
@@ -71,20 +95,15 @@ class DualCanvasRenderer(
         p_black.textSize = 100f
         p_black.strokeWidth = 40f
 
-        val minute = if (zonedDateTime.minute < 10) "0" + zonedDateTime.minute.toString() else zonedDateTime.minute.toString()
+        val minute =
+            if (zonedDateTime.minute < 10) "0" + zonedDateTime.minute.toString() else zonedDateTime.minute.toString()
         val timeText = zonedDateTime.hour.toString() + ":" + minute
 
         val textBounds = Rect()
         p_black.getTextBounds(timeText, 0, timeText.length, textBounds)
-//        canvas.drawText(timeText, h_width, h_height-textBounds.exactCenterY(), p_black)
+        canvas.drawText(timeText, h_width, h_height-textBounds.exactCenterY(), p_black)
 
-        val rectf = RectF(20f, 20f, bounds.width()-20f, bounds.height()-20f)
-        p_black.strokeCap = Paint.Cap.ROUND
-        val path = Path()
-        path.moveTo( 75f, 40f)
-        path.cubicTo(75f, 37f, 70f, 25f, 50f, 25f)
-        
-        canvas.drawArc(rectf, 0f, -180f, true, p_black)
+        canvas.drawText(message, 75f, 37f, p_message)
     }
 
     override fun onTapEvent(tapType: Int, tapEvent: TapEvent, complicationSlot: ComplicationSlot?) {
@@ -96,7 +115,7 @@ class DualCanvasRenderer(
 
 }
 
-class DualAssets: Renderer.SharedAssets {
+class DualAssets : Renderer.SharedAssets {
     override fun onDestroy() {
 
     }

--- a/wear/src/main/java/com/example/wear_study/watchface/DualWatchFaceService.kt
+++ b/wear/src/main/java/com/example/wear_study/watchface/DualWatchFaceService.kt
@@ -1,5 +1,7 @@
 package com.example.wear_study.watchface
 
+import android.content.ContentValues
+import android.util.Log
 import android.view.SurfaceHolder
 import androidx.wear.watchface.CanvasType
 import androidx.wear.watchface.ComplicationSlotsManager
@@ -24,14 +26,13 @@ class DualWatchFaceService: WatchFaceService() {
         complicationSlotsManager: ComplicationSlotsManager,
         currentUserStyleRepository: CurrentUserStyleRepository
     ): WatchFace {
-
         // Creates class that renders the watch face.
         val renderer = DualCanvasRenderer(
-            //context = applicationContext,
+            context = applicationContext,
             surfaceHolder = surfaceHolder,
-            watchState = watchState,
             //complicationSlotsManager = complicationSlotsManager,
             currentUserStyleRepository = currentUserStyleRepository,
+            watchState = watchState,
             canvasType = CanvasType.HARDWARE,
             clearWithBackgroundTintBeforeRenderingHighlightLayer = true,
         )


### PR DESCRIPTION
- mobile에서 wear의 MainActivity로 데이터 전송하기 위해 MessageClient를 사용했고, 
- wear의 MainActivity와 renderer간 데이터를 공유하기 위해 SharedPreferences를 사용했습니다.